### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -1,0 +1,18 @@
+FROM debian:stretch
+
+LABEL maintainer="mgeitz" \
+      version="0.1.1" \
+      description="This image is used to start the tbdchat client executable"
+
+RUN apt-get update -y && apt-get install -y \
+    build-essential \
+    libncurses5-dev \
+    libssl-dev
+
+WORKDIR /bin/tbdc
+
+COPY . .
+
+RUN make chat_client
+
+CMD ./tbdchat

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,0 +1,18 @@
+FROM debian:stretch
+
+LABEL maintainer="mgeitz" \
+      version="0.1.1" \
+      description="This image is used to start the tbdchat server executable"
+
+RUN apt-get update -y && apt-get install -y \
+    build-essential \
+    libncurses5-dev \
+    libssl1.0-dev
+
+WORKDIR /bin/tbdc
+
+COPY . .
+
+RUN make chat_server
+
+CMD tbdchat_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  tbdc:
+    build:
+      context: .
+      dockerfile: Dockerfile-client
+    command: ./tbdchat
+  tbdc_server:
+    build:
+      context: .
+      dockerfile: Dockerfile-server
+    command: tbdchat_server
+    volumes:
+      - .:/bin/tbdc


### PR DESCRIPTION
- Adds support for running the client in docker
```sh
$ docker-compose build tbdc
$ docker-compose run tbdc
```
- Adds stubs for running the server in docker; however, there is a clear
dependency issue compiling the server with the sha256 library.  It
appears this dependency may have been deprecated at the time of
implementation.